### PR TITLE
Add JaCoCo and SonarQube plugins for code coverage and analysis

### DIFF
--- a/Domain/pom.xml
+++ b/Domain/pom.xml
@@ -11,4 +11,16 @@
     <artifactId>Domain</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/Domain/src/test/java/com/school/domain/DomainApplicationTests.java
+++ b/Domain/src/test/java/com/school/domain/DomainApplicationTests.java
@@ -1,3 +1,0 @@
-package com.school.domain;
-
-class DomainApplicationTests {}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+Para lanzar sonar es necesario obtener el token de acceso
+y lanzar el siguiente comando:
+
+```bash 
+    mvn verify sonar:sonar -D sonar.token=TOKEN_OBTENIDO -f pom.xml
+```

--- a/docker-compose-sonarq.yml
+++ b/docker-compose-sonarq.yml
@@ -1,0 +1,62 @@
+services:
+  sonarqube:
+    image: sonarqube:community
+    hostname: sonarqube
+    container_name: sonarqube
+    read_only: true
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SONAR_JDBC_URL: jdbc:postgresql://db:5432/sonar
+      SONAR_JDBC_USERNAME: sonar
+      SONAR_JDBC_PASSWORD: sonar
+    volumes:
+      - sonarqube_data:/opt/sonarqube/data
+      - sonarqube_extensions:/opt/sonarqube/extensions
+      - sonarqube_logs:/opt/sonarqube/logs
+      - sonarqube_temp:/opt/sonarqube/temp
+    ports:
+      - "9000:9000"
+    networks:
+      - ${NETWORK_TYPE:-ipv4}
+  db:
+    image: postgres:17
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    hostname: postgresql
+    container_name: postgresql
+    environment:
+      POSTGRES_USER: sonar
+      POSTGRES_PASSWORD: sonar
+      POSTGRES_DB: sonar
+    volumes:
+      - postgresql:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
+    networks:
+      - ${NETWORK_TYPE:-ipv4}
+
+volumes:
+  sonarqube_data:
+  sonarqube_temp:
+  sonarqube_extensions:
+  sonarqube_logs:
+  postgresql:
+  postgresql_data:
+
+networks:
+  ipv4:
+    driver: bridge
+    enable_ipv6: false
+  dual:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: "192.168.2.0/24"
+          gateway: "192.168.2.1"
+        - subnet: "2001:db8:2::/64"
+          gateway: "2001:db8:2::1"

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,16 @@
 
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
+        <sonar.projectKey>${project.groupId}:${project.artifactId}</sonar.projectKey>
+        <sonar.projectName>${project.groupId}:${project.artifactId}</sonar.projectName>
+        <sonar.host.url>http://localhost:9000</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.exclusions>bootstrap/src/**/SpringAppApplication.java, domain/src/**</sonar.coverage.exclusions>
+        <sonar.exclusions>domain/src/main/java/**/*</sonar.exclusions>
+
     </properties>
 
     <modules>
@@ -85,6 +95,65 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <!-- Plugin for SonarQube analysis -->
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>4.0.0.4121</version>
+            </plugin>
+
+            <!-- Plugin for JaCoCo code coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/domain/**</exclude>
+                                <exclude>**/bootstrap/SpringAppApplication.class</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>CLASS</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.85</minimum>
+                                        </limit>
+                                    </limits>
+                                    <excludes>
+                                        <exclude>**/domain/**</exclude>
+                                    </excludes>
+                                </rule>
+
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
This pull request introduces several significant changes to the project to integrate SonarQube for code quality analysis and JaCoCo for code coverage reporting. Additionally, it includes a configuration for Docker to run SonarQube locally.

Integration of SonarQube and JaCoCo:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R20-R29): Added SonarQube and JaCoCo plugins, along with their configurations, to enable code quality analysis and code coverage reporting. This includes setting properties for the SonarQube project key, name, host URL, and coverage report paths. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R20-R29) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R98-R156)
* [`Domain/pom.xml`](diffhunk://#diff-c3bdcd2876f5a806fdbe8e2a19d455dad9cbfbd56b735b22f37999898268466cR14-R25): Added JaCoCo Maven plugin configuration to skip code coverage during the build.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R6): Added instructions for running SonarQube analysis using Maven with the required token.

Docker configuration for SonarQube:

* [`docker-compose-sonarq.yml`](diffhunk://#diff-4340d297432eee0f8931f35333994a09f763006533613d8a3dcd30d311e622a4R1-R62): Added a Docker Compose configuration to set up SonarQube and PostgreSQL services for local development and testing.

Cleanup:

* [`Domain/src/test/java/com/school/domain/DomainApplicationTests.java`](diffhunk://#diff-d89a9fb4dcc5b4963bd324e82e3f4a099d5f8e72851b82c69a496b97759a69c8L1-L3): Removed an empty test class.